### PR TITLE
Feature/add button to create new group

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ First, you need to configure Gaps by creating a `.env` file and filling in your 
 
     ORG_DOMAIN=
     ORG_NAME=
+    ADD_NEW_GROUP_URL=
     OAUTH_CLIENT_ID=
     OAUTH_CLIENT_SECRET=
     OAUTH_REDIRECT_URL=

--- a/app.json
+++ b/app.json
@@ -10,6 +10,9 @@
     "ORG_NAME": {
       "required": true
     },
+    "ADD_NEW_GROUP_URL": {
+      "required": true
+    },
     "OAUTH_CLIENT_ID": {
       "required": true
     },

--- a/bin/hk-runner
+++ b/bin/hk-runner
@@ -31,6 +31,7 @@ gaps_url: $GAPS_URL
 info:
   domain: $ORG_DOMAIN
   company_name: $ORG_NAME
+  add_new_group_url: $ADD_NEW_GROUP_URL
 
 notify:
   send_email: false

--- a/config.yaml
+++ b/config.yaml
@@ -41,7 +41,7 @@ default: &default
       gaps_scheme: true
       # Whether to use the Google Groups Settings API to decide if a
       # list is private. (Can be composed with the Gaps scheme.)
-      api_scheme: false
+      api_scheme: true
 
   # Whether to fetch the Google Groups settings upon group
   # refresh. Needed to make the api_scheme work. In the future will

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - GAPS_URL=
       - ORG_DOMAIN=
       - ORG_NAME=
+      - ADD_NEW_GROUP_URL=
       - OAUTH_CLIENT_ID=
       - OAUTH_CLIENT_SECRET=
       - OAUTH_REDIRECT_URL=

--- a/views/subs.erb
+++ b/views/subs.erb
@@ -10,6 +10,7 @@ updated within 10 minutes and an automated email sent to <%= configatron.notify.
 
 <p> You are a member of <b><%= @user.group_member_count %></b> <%= @user.group_member_count == 1 ? 'group' : 'groups' %>. </p>
 
+<a href="<%= configatron.info.add_new_group_url %>" class="btn btn-primary" role="button">Create New List</a>
   <form method="POST" action="/subs">
   <%== csrf_tag %>
 <p> <input type="submit" value="Submit changes" /> </p>
@@ -28,6 +29,7 @@ updated within 10 minutes and an automated email sent to <%= configatron.notify.
   <%== csrf_tag %>
   <input type="submit" onclick="return window.confirm('Are you sure? Can take a bit to refresh since we need to requery every group.')" value="Invalidate the group cache" /> (useful if you want a new list to appear right now, but may take a few minutes to repopulate)
 </form>
+<a href="<%= configatron.info.add_new_group_url %>" class="btn btn-primary" role="button">Create New List</a>
 
 <% if @user.admin? %>
 <h2> (Admin only) Login As </h2>

--- a/views/subs.erb
+++ b/views/subs.erb
@@ -10,7 +10,7 @@ updated within 10 minutes and an automated email sent to <%= configatron.notify.
 
 <p> You are a member of <b><%= @user.group_member_count %></b> <%= @user.group_member_count == 1 ? 'group' : 'groups' %>. </p>
 
-<a href="<%= configatron.info.add_new_group_url %>" class="btn btn-primary" role="button">Create New List</a>
+<a href="<%= configatron.info.add_new_group_url %>" class="btn btn-primary" role="button" target="_blank">Create New List</a>
   <form method="POST" action="/subs">
   <%== csrf_tag %>
 <p> <input type="submit" value="Submit changes" /> </p>
@@ -29,7 +29,7 @@ updated within 10 minutes and an automated email sent to <%= configatron.notify.
   <%== csrf_tag %>
   <input type="submit" onclick="return window.confirm('Are you sure? Can take a bit to refresh since we need to requery every group.')" value="Invalidate the group cache" /> (useful if you want a new list to appear right now, but may take a few minutes to repopulate)
 </form>
-<a href="<%= configatron.info.add_new_group_url %>" class="btn btn-primary" role="button">Create New List</a>
+<a href="<%= configatron.info.add_new_group_url %>" class="btn btn-primary" role="button" target="_blank">Create New List</a>
 
 <% if @user.admin? %>
 <h2> (Admin only) Login As </h2>

--- a/views/subs.erb
+++ b/views/subs.erb
@@ -10,10 +10,11 @@ updated within 10 minutes and an automated email sent to <%= configatron.notify.
 
 <p> You are a member of <b><%= @user.group_member_count %></b> <%= @user.group_member_count == 1 ? 'group' : 'groups' %>. </p>
 
-<a href="<%= configatron.info.add_new_group_url %>" class="btn btn-primary" role="button" target="_blank">Create New List</a>
+
+<p><a href="<%= configatron.info.add_new_group_url %>" class="btn btn-primary" role="button" target="_blank">Create New List</a></p>
   <form method="POST" action="/subs">
   <%== csrf_tag %>
-<p> <input type="submit" value="Submit changes" /> </p>
+<p> <input type="submit" value="Submit changes" class="btn btn-success"/> </p>
 
 <div id="categories">
   <% @groups.each do |category, groups| %>
@@ -27,9 +28,9 @@ updated within 10 minutes and an automated email sent to <%= configatron.notify.
 
 <form method="POST" action="/refresh">
   <%== csrf_tag %>
-  <input type="submit" onclick="return window.confirm('Are you sure? Can take a bit to refresh since we need to requery every group.')" value="Invalidate the group cache" /> (useful if you want a new list to appear right now, but may take a few minutes to repopulate)
+  <input type="submit" onclick="return window.confirm('Are you sure? Can take a bit to refresh since we need to requery every group.')" value="Invalidate the group cache" class="btn btn-success"/> (useful if you want a new list to appear right now, but may take a few minutes to repopulate)
 </form>
-<a href="<%= configatron.info.add_new_group_url %>" class="btn btn-primary" role="button" target="_blank">Create New List</a>
+<p><a href="<%= configatron.info.add_new_group_url %>" class="btn btn-primary" role="button" target="_blank">Create New List</a></p>
 
 <% if @user.admin? %>
 <h2> (Admin only) Login As </h2>


### PR DESCRIPTION
I got frustrated that there was no easy way to make a new list, so I added a button that takes the user to the create email list page. URL is set as an environment variable (already set on Heroku).

Also made some of the buttons look nicer